### PR TITLE
chore: Quote build arg values in compose.yaml

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -17,10 +17,10 @@ services:
     build:
       args:
         BASE_IMAGE: public.ecr.aws/ubuntu/ubuntu:24.04
-        DATABRICKS_RUNTIME_VERSION: 16.4
-        JDK_VERSION: 17
+        DATABRICKS_RUNTIME_VERSION: "16.4"
+        JDK_VERSION: "17"
         PYSPARK_VERSION: 3.5.2
-        PYTHON_VERSION: 3.12
+        PYTHON_VERSION: "3.12"
         UV_EXCLUDE_NEWER: "2025-05-09"
       cache_from:
         - ghcr.io/yxtay/databricks-container:16.4
@@ -31,10 +31,10 @@ services:
     build:
       args:
         BASE_IMAGE: public.ecr.aws/ubuntu/ubuntu:22.04
-        DATABRICKS_RUNTIME_VERSION: 15.4
-        JDK_VERSION: 8
+        DATABRICKS_RUNTIME_VERSION: "15.4"
+        JDK_VERSION: "8"
         PYSPARK_VERSION: 3.5.0
-        PYTHON_VERSION: 3.11
+        PYTHON_VERSION: "3.11"
         UV_EXCLUDE_NEWER: "2024-08-19"
       cache_from:
         - ghcr.io/yxtay/databricks-container:15.4
@@ -45,8 +45,8 @@ services:
     build:
       args:
         BASE_IMAGE: public.ecr.aws/ubuntu/ubuntu:22.04
-        DATABRICKS_RUNTIME_VERSION: 14.3
-        JDK_VERSION: 8
+        DATABRICKS_RUNTIME_VERSION: "14.3"
+        JDK_VERSION: "8"
         PYSPARK_VERSION: 3.5.0
         PYTHON_VERSION: "3.10"
         UV_EXCLUDE_NEWER: "2024-02-01"
@@ -59,8 +59,8 @@ services:
     build:
       args:
         BASE_IMAGE: public.ecr.aws/ubuntu/ubuntu:22.04
-        DATABRICKS_RUNTIME_VERSION: 13.3
-        JDK_VERSION: 8
+        DATABRICKS_RUNTIME_VERSION: "13.3"
+        JDK_VERSION: "8"
         PYSPARK_VERSION: 3.4.1
         PYTHON_VERSION: "3.10"
         UV_EXCLUDE_NEWER: "2023-08-22"
@@ -73,10 +73,10 @@ services:
     build:
       args:
         BASE_IMAGE: public.ecr.aws/ubuntu/ubuntu:20.04
-        DATABRICKS_RUNTIME_VERSION: 12.2
-        JDK_VERSION: 8
+        DATABRICKS_RUNTIME_VERSION: "12.2"
+        JDK_VERSION: "8"
         PYSPARK_VERSION: 3.3.2
-        PYTHON_VERSION: 3.9
+        PYTHON_VERSION: "3.9"
         UV_EXCLUDE_NEWER: "2023-03-01"
       cache_from:
         - ghcr.io/yxtay/databricks-container:12.2
@@ -87,10 +87,10 @@ services:
     build:
       args:
         BASE_IMAGE: public.ecr.aws/ubuntu/ubuntu:20.04
-        DATABRICKS_RUNTIME_VERSION: 11.3
-        JDK_VERSION: 8
+        DATABRICKS_RUNTIME_VERSION: "11.3"
+        JDK_VERSION: "8"
         PYSPARK_VERSION: 3.3.0
-        PYTHON_VERSION: 3.9
+        PYTHON_VERSION: "3.9"
         UV_EXCLUDE_NEWER: "2022-10-19"
       cache_from:
         - ghcr.io/yxtay/databricks-container:11.3
@@ -101,10 +101,10 @@ services:
     build:
       args:
         BASE_IMAGE: public.ecr.aws/ubuntu/ubuntu:20.04
-        DATABRICKS_RUNTIME_VERSION: 10.4
-        JDK_VERSION: 8
+        DATABRICKS_RUNTIME_VERSION: "10.4"
+        JDK_VERSION: "8"
         PYSPARK_VERSION: 3.2.1
-        PYTHON_VERSION: 3.8
+        PYTHON_VERSION: "3.8"
         UV_EXCLUDE_NEWER: "2022-03-18"
       cache_from:
         - ghcr.io/yxtay/databricks-container:10.4
@@ -115,10 +115,10 @@ services:
     build:
       args:
         BASE_IMAGE: public.ecr.aws/ubuntu/ubuntu:20.04
-        DATABRICKS_RUNTIME_VERSION: 9.4
-        JDK_VERSION: 8
+        DATABRICKS_RUNTIME_VERSION: "9.4"
+        JDK_VERSION: "8"
         PYSPARK_VERSION: 3.1.2
-        PYTHON_VERSION: 3.8
+        PYTHON_VERSION: "3.8"
         UV_EXCLUDE_NEWER: "2021-09-23"
       cache_from:
         - ghcr.io/yxtay/databricks-container:9.4


### PR DESCRIPTION
Enclosed DATABRICKS_RUNTIME_VERSION, JDK_VERSION, and PYTHON_VERSION build argument values in quotes for all services. This ensures correct parsing of version numbers as strings in Docker Compose.